### PR TITLE
Allow for STATSD_PORT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ plugin :statsd
 
 ## Usage
 
-Ensure you have an environment variable set that points to a statsd host, then boot your puma app as usual
+Ensure you have an environment variable set that points to a statsd host, then boot your puma app as usual.  Optionally you may specify a port (default is 8125). 
 
 ```
 STATSD_HOST=127.0.0.1 bundle exec puma
 ```
 
 ```
-STATSD_HOST=127.0.0.1 MY_POD_NAME=foo bundle exec puma
+STATSD_HOST=127.0.0.1 MY_POD_NAME=foo STATSD_PORT=9125 bundle exec puma
 ```
 
 ### Datadog Integration

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -10,13 +10,13 @@ Puma::Plugin.create do
 
   class Statsd
     ENV_NAME = "STATSD_HOST"
-    STATSD_PORT = 8125
     STATSD_TYPES = { count: 'c', gauge: 'g' }
 
-    attr_reader :host
+    attr_reader :host, :port
 
     def initialize
       @host = ENV.fetch(ENV_NAME, nil)
+      @port = ENV.fetch("STATSD_PORT", 8125)
     end
 
     def enabled?
@@ -30,7 +30,7 @@ Puma::Plugin.create do
         data = "#{data}|##{tag_str}"
       end
 
-      UDPSocket.new.send(data, 0, host, STATSD_PORT)
+      UDPSocket.new.send(data, 0, host, port)
     end
   end
 


### PR DESCRIPTION
We don't use the default port, so it'd be helpful to be able to specify a port.