### PR TITLE
Ensure UDP sockets are closed

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -26,7 +26,10 @@ class StatsdConnector
       data = "#{data}|##{tag_str}"
     end
 
-    UDPSocket.new.send(data, 0, host, port)
+    socket = UDPSocket.new
+    socket.send(data, 0, host, port)
+  ensure
+    socket.close
   end
 end
 


### PR DESCRIPTION
Thank you for good rubygem!

I found that Rails application with this rubygem failed to launch because of `Too many open files` error. I fixed codes to ensure that UDP sockets are always closed.