### PR TITLE
Add possibility to configure StatsD prefix via env variable

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -7,6 +7,7 @@ require 'socket'
 class StatsdConnector
   ENV_NAME = "STATSD_HOST"
   STATSD_TYPES = { count: 'c', gauge: 'g' }
+  DELIMETER = '.'.freeze
 
   attr_reader :host, :port
 
@@ -14,7 +15,7 @@ class StatsdConnector
     @host = ENV.fetch(ENV_NAME, nil)
     @port = ENV.fetch("STATSD_PORT", 8125)
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
-    @metric_prefix += ":" if @metric_prefix && !@metric_prefix.end_with?(":")
+    @metric_prefix += DELIMETER if @metric_prefix && !@metric_prefix.end_with?(DELIMETER)
   end
 
   def enabled?

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -7,15 +7,13 @@ require 'socket'
 class StatsdConnector
   ENV_NAME = "STATSD_HOST"
   STATSD_TYPES = { count: 'c', gauge: 'g' }
-  DELIMETER = '.'.freeze
+  METRIC_DELIMETER = ".".freeze
 
   attr_reader :host, :port
 
   def initialize
     @host = ENV.fetch(ENV_NAME, nil)
     @port = ENV.fetch("STATSD_PORT", 8125)
-    @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
-    @metric_prefix += DELIMETER if @metric_prefix && !@metric_prefix.end_with?(DELIMETER)
   end
 
   def enabled?
@@ -23,7 +21,7 @@ class StatsdConnector
   end
 
   def send(metric_name:, value:, type:, tags: {})
-    data = "#{@metric_prefix}#{metric_name}:#{value}|#{STATSD_TYPES.fetch(type)}"
+    data = "#{metric_name}:#{value}|#{STATSD_TYPES.fetch(type)}"
     if tags.any?
       tag_str = tags.map { |k,v| "#{k}:#{v}" }.join(",")
       data = "#{data}|##{tag_str}"
@@ -100,6 +98,13 @@ Puma::Plugin.create do
     @statsd = ::StatsdConnector.new
     if @statsd.enabled?
       @launcher.events.debug "statsd: enabled (host: #{@statsd.host})"
+
+      # Fetch global metric prefix from env variable
+      @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
+      if @metric_prefix && !@metric_prefix.end_with?(::StatsdConnector::METRIC_DELIMETER)
+        @metric_prefix += ::StatsdConnector::METRIC_DELIMETER
+      end
+
       register_hooks
     else
       @launcher.events.debug "statsd: not enabled (no #{StatsdConnector::ENV_NAME} env var found)"
@@ -127,6 +132,10 @@ Puma::Plugin.create do
     tags
   end
 
+  def prefixed_metric_name(puma_metric)
+    "#{@metric_prefix}#{puma_metric}"
+  end
+
   # Send data to statsd every few seconds
   def stats_loop
     sleep 5
@@ -134,12 +143,12 @@ Puma::Plugin.create do
       @launcher.events.debug "statsd: notify statsd"
       begin
         stats = ::PumaStats.new(fetch_stats)
-        @statsd.send(metric_name: "puma.workers", value: stats.workers, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.booted_workers", value: stats.booted_workers, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.running", value: stats.running, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.backlog", value: stats.backlog, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.pool_capacity", value: stats.pool_capacity, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.max_threads", value: stats.max_threads, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.booted_workers"), value: stats.booted_workers, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.running"), value: stats.running, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.backlog"), value: stats.backlog, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.pool_capacity"), value: stats.pool_capacity, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
       rescue StandardError => e
         @launcher.events.error "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
       ensure

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -14,7 +14,7 @@ class StatsdConnector
     @host = ENV.fetch(ENV_NAME, nil)
     @port = ENV.fetch("STATSD_PORT", 8125)
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
-    @metric_prefix += ":" if @metric_prefix
+    @metric_prefix += ":" if @metric_prefix && !@metric_prefix.end_with?(":")
   end
 
   def enabled?

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -13,6 +13,8 @@ class StatsdConnector
   def initialize
     @host = ENV.fetch(ENV_NAME, nil)
     @port = ENV.fetch("STATSD_PORT", 8125)
+    @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
+    @metric_prefix += ":" if @metric_prefix
   end
 
   def enabled?
@@ -20,7 +22,7 @@ class StatsdConnector
   end
 
   def send(metric_name:, value:, type:, tags: {})
-    data = "#{metric_name}:#{value}|#{STATSD_TYPES.fetch(type)}"
+    data = "#{@metric_prefix}#{metric_name}:#{value}|#{STATSD_TYPES.fetch(type)}"
     if tags.any?
       tag_str = tags.map { |k,v| "#{k}:#{v}" }.join(",")
       data = "#{data}|##{tag_str}"


### PR DESCRIPTION
This allows to pass global prefix for StatsD metrics via `STATSD_METRIC_PREFIX` environment variable.

Also should fix https://github.com/yob/puma-plugin-statsd/issues/6.