### PR TITLE
Support for use with Puma 5

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -86,11 +86,6 @@ class PumaStats
 end
 
 Puma::Plugin.create do
-  # Puma creates the plugin when encountering `plugin` in the config.
-  def initialize(loader)
-    @loader = loader
-  end
-
   # We can start doing something when we have a launcher:
   def start(launcher)
     @launcher = launcher

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md", "MIT-LICENSE"]
 
-  spec.add_runtime_dependency "puma", ">= 3.12", "< 5"
+  spec.add_runtime_dependency "puma", ">= 3.12", "< 6"
   spec.add_runtime_dependency "json"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This bumps the version in the gemspec to `< 6` to be able to update to Puma 5.

It also removes the intializer from inside `Puma::Plugin.create`. This was removed in Puma [here](https://github.com/puma/puma/commit/62eae2683debd5cacb271b54dac7645e3490a582#diff-e897820765f1098c2b56bc7417b49cdd).

Running the commands listed in the README for [Testing the data being sent to statsd](https://github.com/yob/puma-plugin-statsd#testing-the-data-being-sent-to-statsd)
```
$ ruby devtools/statsd-to-stdout.rb
127.0.0.1:puma.workers:1|g
127.0.0.1:puma.booted_workers:1|g
127.0.0.1:puma.running:0|g
127.0.0.1:puma.backlog:0|g
127.0.0.1:puma.pool_capacity:0|g
127.0.0.1:puma.max_threads:0|g
127.0.0.1:puma.workers:1|g
127.0.0.1:puma.booted_workers:1|g
127.0.0.1:puma.running:8|g
127.0.0.1:puma.backlog:0|g
127.0.0.1:puma.pool_capacity:16|g
127.0.0.1:puma.max_threads:16|g
127.0.0.1:puma.workers:1|g
127.0.0.1:puma.booted_workers:1|g
127.0.0.1:puma.running:8|g
127.0.0.1:puma.backlog:0|g
127.0.0.1:puma.pool_capacity:16|g
127.0.0.1:puma.max_threads:16|g
```

```
$ STATSD_HOST=127.0.0.1 bundle exec puma devtools/config.ru --config devtools/puma-config.rb
[16542] Puma starting in cluster mode...
[16542] * Version 5.0.0 (ruby 2.7.1-p83), codename: Spoony Bard
[16542] * Min threads: 8, max threads: 16
[16542] * Environment: development
[16542] * Process workers: 1
[16542] * Phased restart available
[16542] * Listening on http://127.0.0.1:9292
[16542] Use Ctrl-C to stop
[16542] - Worker 0 (pid: 16543) booted, phase: 0
^C[16542] - Gracefully shutting down workers...
[16542] === puma shutdown: 2020-09-23 05:20:19 -0700 ===
[16542] - Goodbye!
```

```
$  curl http://127.0.0.1:9292/
Put this in your pipe & smoke it!
```

System: Mac OS 10.15.6
Ruby: 2.7.1