### PR TITLE
Increase recvfrom buffer to 64k

### DIFF
--- a/devtools/statsd-to-stdout.rb
+++ b/devtools/statsd-to-stdout.rb
@@ -1,11 +1,14 @@
 # encoding: utf-8
+
+RECV_BUFFER = 64*1024
+
 require 'socket'
 server = UDPSocket.new
 host, port = "127.0.0.1", 8125
 server.bind(host, port)
 
 while true
-  text, sender = server.recvfrom(64)
+  text, sender = server.recvfrom(RECV_BUFFER)
   remote_host = sender[3]
   STDOUT.puts "#{remote_host}:" + text
 end


### PR DESCRIPTION
Without this adjustment, debug output would be truncated with a long prefix or
a long set of datadog-tags.

The real-life limit is probably not 64k, but the previous value of 64 bytes was
significantly smaller than our real-world use.

https://github.com/statsd/statsd/blob/master/docs/metric_types.md#multi-metric-packets