### PR TITLE
The plugin is always enabled now

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -16,10 +16,6 @@ class StatsdConnector
     @port = ENV.fetch("STATSD_PORT", 8125)
   end
 
-  def enabled?
-    !!host
-  end
-
   def send(metric_name:, value:, type:, tags: nil)
     data = "#{metric_name}:#{value}|#{STATSD_TYPES.fetch(type)}"
     data = "#{data}|##{tags}" unless tags.nil?
@@ -88,19 +84,15 @@ Puma::Plugin.create do
     @launcher = launcher
 
     @statsd = ::StatsdConnector.new
-    if @statsd.enabled?
-      @launcher.events.debug "statsd: enabled (host: #{@statsd.host})"
+    @launcher.events.debug "statsd: enabled (host: #{@statsd.host})"
 
-      # Fetch global metric prefix from env variable
-      @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
-      if @metric_prefix && !@metric_prefix.end_with?(::StatsdConnector::METRIC_DELIMETER)
-        @metric_prefix += ::StatsdConnector::METRIC_DELIMETER
-      end
-
-      register_hooks
-    else
-      @launcher.events.debug "statsd: not enabled (no #{StatsdConnector::ENV_NAME} env var found)"
+    # Fetch global metric prefix from env variable
+    @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
+    if @metric_prefix && !@metric_prefix.end_with?(::StatsdConnector::METRIC_DELIMETER)
+      @metric_prefix += ::StatsdConnector::METRIC_DELIMETER
     end
+
+    register_hooks
   end
 
   private


### PR DESCRIPTION
Since PR #20, this plugin is always enabled and we default to assuming stats is listening on 127.0.0.1. That makes the else branch of this method dead code.