### PR TITLE
delay requiring the json gem until runtime

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -1,5 +1,4 @@
 # coding: utf-8, frozen_string_literal: true
-require "json"
 require "puma"
 require "puma/plugin"
 require 'socket'
@@ -115,6 +114,7 @@ Puma::Plugin.create do
     end
   else
     def fetch_stats
+      require "json"
       stats = Puma.stats
       JSON.parse(stats, symbolize_names: true)
     end


### PR DESCRIPTION
We can run into trouble if puma loads before bundler - ruby might load the latest json gem it can find, which might then conflict with the json gem version required by bundler.

For now I'll fix that by requiring json at run time, even though it'll be a no-op in most cases. It's inefficient, but it should work.

At some point soon I'll release v2.0 of this plugin and require puma 5+, allowing us to rely on #stats_hash and remove all JSON parsing.

Closes #23