### PR TITLE
require puma 5 or better

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -112,18 +112,6 @@ Puma::Plugin.create do
     in_background(&method(:stats_loop))
   end
 
-  if Puma.respond_to?(:stats_hash)
-    def fetch_stats
-      Puma.stats_hash
-    end
-  else
-    def fetch_stats
-      require "json"
-      stats = Puma.stats
-      JSON.parse(stats, symbolize_names: true)
-    end
-  end
-
   def environment_variable_tags
     # Tags are separated by spaces, and while they are normally a tag and
     # value separated by a ':', they can also just be tagged without any
@@ -171,7 +159,7 @@ Puma::Plugin.create do
     loop do
       @launcher.events.debug "statsd: notify statsd"
       begin
-        stats = ::PumaStats.new(fetch_stats)
+        stats = ::PumaStats.new(Puma.stats_hash)
         @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.booted_workers"), value: stats.booted_workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.old_workers"), value: stats.old_workers, type: :gauge, tags: tags)

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md", "MIT-LICENSE"]
 
-  spec.add_runtime_dependency "puma", ">= 3.12", "< 6"
+  spec.add_runtime_dependency "puma", ">= 5.0", "< 6"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
puma 5 added a new API for fetching the stats as a plain ruby Hash, with no need to deserialise JSON.

Avoiding JSON is nice, because the json gem is a "default gem" that loads differently and it's difficult to require without load order issues.

I plan to release this as v2.x, so folks on older puma versions can continue using the 1.x series.