### PR TITLE
Split DD_TAGS by spaces and commas

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -135,7 +135,7 @@ Puma::Plugin.create do
     # https://docs.datadoghq.com/agent/docker/?tab=standard#global-options
     #
     if ENV.has_key?("DD_TAGS")
-      ENV["DD_TAGS"].split(/\s+/).each do |t|
+      ENV["DD_TAGS"].split(/\s+|,/).each do |t|
         tags << t
       end
     end


### PR DESCRIPTION
The DataDog [documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#environment-and-tags) shows the tags as being delimited by commas. To support their documentation and backwards compatibility this plugin should support spaces and commas.