### PR TITLE
Use alternative logging method that doesn't kill the server

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -169,7 +169,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
       rescue StandardError => e
-        @launcher.events.error "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
+        @launcher.events.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
         sleep 2
       end


### PR DESCRIPTION
The previous behaviour of Puma when @launcher.events.error is used is to
kill the server. However, doesn't seem like a Plugin should be able to
do that.

https://github.com/puma/puma/blame/master/lib/puma/events.rb#L83

Fix for #34 