### PR TITLE
Fix Markdown Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puma Statsd Plugin
 
-[Puma][puma] integration with [statsd](statsd) for easy tracking of key metrics
+[Puma][puma] integration with [statsd][statsd] for easy tracking of key metrics
 that puma can provide:
 
 * puma.workers


### PR DESCRIPTION
## Why

`[systemd](systemd)` wasn't picking up the link reference definition thus was 404ing<sup>[1](https://github.github.com/gfm/#example-535)</sup>