### PR TITLE
Allow sleep interval to be configured with STATSD_SLEEP_INTERNAL environment variable

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -102,7 +102,8 @@ Puma::Plugin.create do
     @launcher = launcher
 
     @statsd = ::StatsdConnector.new
-    @launcher.events.debug "statsd: enabled (host: #{@statsd.host})"
+    @interval = ENV.fetch("STATSD_SLEEP_INTERNAL", "2").to_f
+    @launcher.events.debug "statsd: enabled (host: #{@statsd.host}, interval: #{@interval})"
 
     # Fetch global metric prefix from env variable
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
@@ -194,7 +195,7 @@ Puma::Plugin.create do
       rescue StandardError => e
         @launcher.events.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
-        sleep 2
+        sleep @interval
       end
     end
   end


### PR DESCRIPTION
it can be useful to get more fine grained sampling of the metrics