### PR TITLE
Add support for Datadog origin detection

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -163,6 +163,14 @@ Puma::Plugin.create do
       tags << "version:#{ENV["DD_VERSION"]}"
     end
 
+    # Support the origin detection over UDP from Datadog, it allows DogStatsD
+    # to detect where the container metrics come from, and tag metrics automatically.
+    #
+    # https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
+    if ENV.has_key?("DD_ENTITY_ID")
+      tags << "dd.internal.entity_id:#{ENV["DD_ENTITY_ID"]}"
+    end
+
     # Return nil if we have no environment variable tags. This way we don't
     # send an unnecessary '|' on the end of each stat
     return nil if tags.empty?


### PR DESCRIPTION
Add support for datadog origin detection over UDP.

It allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. 

Reference document
https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp

Reference code in dogstats-ruby gem
https://github.com/DataDog/dogstatsd-ruby/blob/5cb9a87154674f66ac740606d58315213ab7775b/lib/datadog/statsd/serialization/tag_serializer.rb#L87