### PR TITLE
Improve performance using `Array#sum`

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -57,7 +57,7 @@ class PumaStats
 
   def running
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:running, 0) }.inject(0, &:+)
+      @stats[:worker_status].sum(0) { |s| s[:last_status].fetch(:running, 0) }
     else
       @stats.fetch(:running, 0)
     end
@@ -65,7 +65,7 @@ class PumaStats
 
   def backlog
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:backlog, 0) }.inject(0, &:+)
+      @stats[:worker_status].sum(0) { |s| s[:last_status].fetch(:backlog, 0) }
     else
       @stats.fetch(:backlog, 0)
     end
@@ -73,7 +73,7 @@ class PumaStats
 
   def pool_capacity
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:pool_capacity, 0) }.inject(0, &:+)
+      @stats[:worker_status].sum(0) { |s| s[:last_status].fetch(:pool_capacity, 0) }
     else
       @stats.fetch(:pool_capacity, 0)
     end
@@ -81,7 +81,7 @@ class PumaStats
 
   def max_threads
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:max_threads, 0) }.inject(0, &:+)
+      @stats[:worker_status].sum(0) { |s| s[:last_status].fetch(:max_threads, 0) }
     else
       @stats.fetch(:max_threads, 0)
     end
@@ -89,7 +89,7 @@ class PumaStats
 
   def requests_count
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:requests_count, 0) }.inject(0, &:+)
+      @stats[:worker_status].sum(0) { |s| s[:last_status].fetch(:requests_count, 0) }
     else
       @stats.fetch(:requests_count, 0)
     end


### PR DESCRIPTION
The following micro benchmark shows `Array#sum` is better than `Array#map` with `Array#inject`.
``` ruby
require 'benchmark'

array = 4.times.to_a

Benchmark.bm(24) {|x|
  x.report('Array#sum') do
    100000.times {
      array.sum(0, &:itself)
    }
  end

  x.report('Array#map & Array#inject') do
    100000.times {
      array.map(&:itself).inject(0, &:+)
    }
  end
}
```

```
                               user     system      total        real
Array#sum                  0.014578   0.000027   0.014605 (  0.014607)
Array#map & Array#inject   0.040410   0.000191   0.040601 (  0.040623)
```