### PR TITLE
Fix magic comment: `frozen_string_literal: true`

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -1,4 +1,5 @@
-# coding: utf-8, frozen_string_literal: true
+# coding: utf-8
+# frozen_string_literal: true
 require "puma"
 require "puma/plugin"
 require 'socket'
@@ -6,7 +7,7 @@ require 'socket'
 class StatsdConnector
   ENV_NAME = "STATSD_HOST"
   STATSD_TYPES = { count: 'c', gauge: 'g' }
-  METRIC_DELIMETER = ".".freeze
+  METRIC_DELIMETER = "."
 
   attr_reader :host, :port
 


### PR DESCRIPTION
This should be started with `#`, not enumerated with comma.

## Current (Not expected)
``` ruby
# coding: utf-8, frozen_string_literal: true

a = "a"
a.frozen? #=> false
a.succ! #=> "b"
```

## Expected
``` ruby
# coding: utf-8
# frozen_string_literal: true

a = "a"
a.frozen? #=> true
a.succ! #=> can't modify frozen String: "a" (FrozenError)
```