### PR TITLE
Percent busy metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ you can add the following to your `config/puma.rb` (values are examples):
   end
 ```
 
+#### Configure metric types
+By default, the following metrics is gathered: 
+
+* `workers`
+* `booted_workers`
+* `old_workers`
+* `running`
+* `backlog`
+* `max_threads`
+* `requests_count`
+
+All is collected with `:gauge` type. Via advanced configuration you can change it like this:
+
+```ruby
+  ::PumaStatsd.configure do |config|
+    config.metrics[:backlog] = :histogram # :count, :gauge and :histogram is supported
+    config.metrics.delete(:old_workers)
+  end
+```
+
+Stats is calculated as a method called on `PumaStatsd::PumaStats` instance. See
+source code for more details.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ env:
     value: deployment-foo
 ```
 
+#### STATSD_SLEEP_INTERVAL
+Stats loop by default runs every two seconds. You may want to lower that to get more fine grained sampling of the metrics or to stats be able to report quicker after an error. Sleep interval is configurable via `STATSD_SLEEP_INVERVAL` environment variable. For example:
+
+```bash
+export STATSD_SLEEP_INTERVAL='0.5'
+bundle exec rails server
+```
+
+`String#to_f` will be called on provided value.
+
 #### Advanced configuration
 You may want to use different environment variable names, for instance if you
 happen to already provide same values with another names for another reasons,

--- a/README.md
+++ b/README.md
@@ -103,10 +103,36 @@ env:
     value: deployment-foo
 ```
 
+#### Advanced configuration
+You may want to use different environment variable names, for instance if you
+happen to already provide same values with another names for another reasons,
+and want to avoid duplication. You also may want to compute some values from
+other values. Finally, you may want to enable the plugin conditionally. In any
+case, there's an interface to configure plugin from ruby. If you want to do so,
+you can add the following to your `config/puma.rb` (values are examples):
+
+```ruby
+  plugin :statsd
+
+  ::PumaStatsd.configure do |config|
+    config.pod_name = ENV.fetch('HOSTNAME')
+    # Extract deployment name from pod name
+    config.statsd_grouping = ENV.fetch('HOSTNAME').sub(/\-[a-z0-9]+\-[a-z0-9]{5}$/, '')
+    config.statsd_host = ENV.fetch('DD_HOST')
+    config.statsd_port = ENV.fetch('DD_STATSD_PORT')
+  end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/yob/puma-plugin-statsd.
+
+### Tests
+
+This gem uses MiniTest for unit testing.
+
+Run tests with `rake test`.
 
 ## Testing the data being sent to statsd
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ By default, the following metrics is gathered:
 * `backlog`
 * `max_threads`
 * `requests_count`
+* `percent_busy` -- how much of the pool capacity is taken already
 
-All is collected with `:gauge` type. Via advanced configuration you can change it like this:
+All is collected with `:gauge` type, except `:percent_busy`, which is collected
+with `:histogram` type. Via advanced configuration you can change it like this:
 
 ```ruby
   ::PumaStatsd.configure do |config|

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -1,20 +1,47 @@
 # coding: utf-8
 # frozen_string_literal: true
-require "puma"
-require "puma/plugin"
+require 'puma'
+require 'puma/plugin'
 require 'socket'
+require 'ostruct'
+
+module PumaStatsd
+  def self.config
+    @config ||= OpenStruct.new({
+      statsd_host: ENV.fetch(StatsdConnector::ENV_NAME, '127.0.0.1'),
+      statsd_port: ENV.fetch('STATSD_PORT', 8125),
+      statsd_socket_path: ENV.fetch('STATSD_SOCKET_PATH', nil),
+      pod_name: ENV.fetch('MY_POD_NAME', nil),
+      statsd_grouping: ENV.fetch('STATSD_GROUPING', nil),
+      metric_prefix: ENV.fetch('STATSD_METRIC_PREFIX', nil),
+      dd_tags: ENV.fetch('DD_TAGS', nil),
+      dd_env: ENV.fetch('DD_ENV', nil),
+      dd_service: ENV.fetch('DD_SERVICE', nil),
+      dd_version: ENV.fetch('DD_VERSION', nil),
+      dd_entity_id: ENV.fetch('DD_ENTITY_ID', nil)
+    })
+  end
+
+  def self.configure
+    yield config
+  end
+
+  def self.reset_config
+    @config = nil
+  end
+end
 
 class StatsdConnector
-  ENV_NAME = "STATSD_HOST"
+  ENV_NAME = 'STATSD_HOST'
   STATSD_TYPES = { count: 'c', gauge: 'g' }
-  METRIC_DELIMETER = "."
+  METRIC_DELIMETER = '.'
 
   attr_reader :host, :port
 
   def initialize
-    @host = ENV.fetch(ENV_NAME, "127.0.0.1")
-    @port = ENV.fetch("STATSD_PORT", 8125)
-    @socket_path = ENV.fetch("STATSD_SOCKET_PATH", nil)
+    @host = ::PumaStatsd.config.statsd_host
+    @port = ::PumaStatsd.config.statsd_port
+    @socket_path = ::PumaStatsd.config.statsd_socket_path
   end
 
   def send(metric_name:, value:, type:, tags: nil)
@@ -26,11 +53,17 @@ class StatsdConnector
       socket.connect(Socket.pack_sockaddr_un(@socket_path))
       socket.sendmsg_nonblock(data)
     else
-      socket = UDPSocket.new
+      socket = udp_socket
       socket.send(data, 0, host, port)
     end
   ensure
     socket.close
+  end
+
+  private
+
+  def udp_socket
+    UDPSocket.new
   end
 end
 
@@ -112,7 +145,7 @@ Puma::Plugin.create do
     @log_writer.debug "statsd: enabled (host: #{@statsd.host})"
 
     # Fetch global metric prefix from env variable
-    @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
+    @metric_prefix = PumaStatsd.config.metric_prefix
     if @metric_prefix && !@metric_prefix.end_with?(::StatsdConnector::METRIC_DELIMETER)
       @metric_prefix += ::StatsdConnector::METRIC_DELIMETER
     end
@@ -135,12 +168,12 @@ Puma::Plugin.create do
     #
     tags = []
 
-    if ENV.has_key?("MY_POD_NAME")
-      tags << "pod_name:#{ENV['MY_POD_NAME']}"
+    if ::PumaStatsd.config.pod_name
+      tags << "pod_name:#{::PumaStatsd.config.pod_name}"
     end
 
-    if ENV.has_key?("STATSD_GROUPING")
-      tags << "grouping:#{ENV['STATSD_GROUPING']}"
+    if ::PumaStatsd.config.statsd_grouping
+      tags << "grouping:#{::PumaStatsd.config.statsd_grouping}"
     end
 
     # Standardised datadog tag attributes, so that we can share the metric
@@ -148,8 +181,8 @@ Puma::Plugin.create do
     #
     # https://docs.datadoghq.com/agent/docker/?tab=standard#global-options
     #
-    if ENV.has_key?("DD_TAGS")
-      ENV["DD_TAGS"].split(/\s+|,/).each do |t|
+    if ::PumaStatsd.config.dd_tags
+      ::PumaStatsd.config.dd_tags.split(/\s+|,/).each do |t|
         tags << t
       end
     end
@@ -158,24 +191,24 @@ Puma::Plugin.create do
     # the metric tags with the application running
     #
     # https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
-    if ENV.has_key?("DD_ENV")
-      tags << "env:#{ENV["DD_ENV"]}"
+    if ::PumaStatsd.config.dd_env
+      tags << "env:#{::PumaStatsd.config.dd_env}"
     end
 
-    if ENV.has_key?("DD_SERVICE")
-      tags << "service:#{ENV["DD_SERVICE"]}"
+    if ::PumaStatsd.config.dd_service
+      tags << "service:#{::PumaStatsd.config.dd_service}"
     end
 
-    if ENV.has_key?("DD_VERSION")
-      tags << "version:#{ENV["DD_VERSION"]}"
+    if ::PumaStatsd.config.dd_version
+      tags << "version:#{::PumaStatsd.config.dd_version}"
     end
 
     # Support the origin detection over UDP from Datadog, it allows DogStatsD
     # to detect where the container metrics come from, and tag metrics automatically.
     #
     # https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
-    if ENV.has_key?("DD_ENTITY_ID")
-      tags << "dd.internal.entity_id:#{ENV["DD_ENTITY_ID"]}"
+    if ::PumaStatsd.config.dd_entity_id
+      tags << "dd.internal.entity_id:#{::PumaStatsd.config.dd_entity_id}"
     end
 
     # Return nil if we have no environment variable tags. This way we don't
@@ -198,14 +231,14 @@ Puma::Plugin.create do
       @log_writer.debug "statsd: notify statsd"
       begin
         stats = ::PumaStats.new(Puma.stats_hash)
-        @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.booted_workers"), value: stats.booted_workers, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.old_workers"), value: stats.old_workers, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.running"), value: stats.running, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.backlog"), value: stats.backlog, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.pool_capacity"), value: stats.pool_capacity, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.workers'), value: stats.workers, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.booted_workers'), value: stats.booted_workers, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.old_workers'), value: stats.old_workers, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.running'), value: stats.running, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.backlog'), value: stats.backlog, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.pool_capacity'), value: stats.pool_capacity, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.max_threads'), value: stats.max_threads, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name('puma.requests_count'), value: stats.requests_count, type: :gauge, tags: tags)
       rescue StandardError => e
         @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -13,6 +13,7 @@ module PumaStatsd
       statsd_socket_path: ENV.fetch('STATSD_SOCKET_PATH', nil),
       pod_name: ENV.fetch('MY_POD_NAME', nil),
       statsd_grouping: ENV.fetch('STATSD_GROUPING', nil),
+      statsd_sleep_interval: ENV.fetch('STATSD_SLEEP_INTERVAL', '2'),
       metric_prefix: ENV.fetch('STATSD_METRIC_PREFIX', nil),
       dd_tags: ENV.fetch('DD_TAGS', nil),
       dd_env: ENV.fetch('DD_ENV', nil),
@@ -242,7 +243,7 @@ Puma::Plugin.create do
       rescue StandardError => e
         @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
-        sleep 2
+        sleep ::PumaStatsd.config.statsd_sleep_interval.to_f
       end
     end
   end

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -27,7 +27,8 @@ module PumaStatsd
         running: :gauge,
         backlog: :gauge,
         max_threads: :gauge,
-        requests_count: :gauge
+        requests_count: :gauge,
+        percent_busy: :histogram
       }
     })
   end
@@ -137,6 +138,11 @@ class PumaStats
     else
       @stats.fetch(:requests_count, 0)
     end
+  end
+
+  def percent_busy
+    return 0 if max_threads == 0
+    ((1.0 - pool_capacity.to_f/max_threads.to_f)*100).round
   end
 end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -14,6 +14,7 @@ class ConfigTest < MiniTest::Test
         MY_POD_NAME
         STATSD_GROUPING
         STATSD_METRIC_PREFIX
+        STATSD_SLEEP_INTERVAL
         DD_TAGS
         DD_ENV
         DD_SERVICE
@@ -35,23 +36,25 @@ class ConfigTest < MiniTest::Test
   end
 
   def test_config_from_default_env
-    ENV['STATSD_HOST']          = 'test.com'
-    ENV['STATSD_PORT']          = '1234'
-    ENV['MY_POD_NAME']          = 'sample_pod'
-    ENV['STATSD_SOCKET_PATH']   = '/var/lib/statsd/statsd.sock'
-    ENV['STATSD_GROUPING']      = 'sample_group'
-    ENV['STATSD_METRIC_PREFIX'] = 'sample'
-    ENV['DD_TAGS']              = 'aaa,bbb'
-    ENV['DD_ENV']               = 'staging'
-    ENV['DD_SERVICE']           = 'sample_service'
-    ENV['DD_VERSION']           = '2.0.0'
-    ENV['DD_ENTITY_ID']         = 'sample_entity_id'
+    ENV['STATSD_HOST']           = 'test.com'
+    ENV['STATSD_PORT']           = '1234'
+    ENV['MY_POD_NAME']           = 'sample_pod'
+    ENV['STATSD_SOCKET_PATH']    = '/var/lib/statsd/statsd.sock'
+    ENV['STATSD_GROUPING']       = 'sample_group'
+    ENV['STATSD_METRIC_PREFIX']  = 'sample'
+    ENV['STATSD_SLEEP_INTERVAL'] = '0.5'
+    ENV['DD_TAGS']               = 'aaa,bbb'
+    ENV['DD_ENV']                = 'staging'
+    ENV['DD_SERVICE']            = 'sample_service'
+    ENV['DD_VERSION']            = '2.0.0'
+    ENV['DD_ENTITY_ID']          = 'sample_entity_id'
 
     assert_equal 'test.com'                   , PumaStatsd.config.statsd_host
     assert_equal '1234'                       , PumaStatsd.config.statsd_port
     assert_equal 'sample_pod'                 , PumaStatsd.config.pod_name
     assert_equal '/var/lib/statsd/statsd.sock', PumaStatsd.config.statsd_socket_path
     assert_equal 'sample_group'               , PumaStatsd.config.statsd_grouping
+    assert_equal '0.5'                        , PumaStatsd.config.statsd_sleep_interval
     assert_equal 'sample'                     , PumaStatsd.config.metric_prefix
     assert_equal 'aaa,bbb'                    , PumaStatsd.config.dd_tags
     assert_equal 'staging'                    , PumaStatsd.config.dd_env
@@ -62,17 +65,18 @@ class ConfigTest < MiniTest::Test
 
   def test_configure_block
     PumaStatsd.configure do |config|
-      config.statsd_host         = 'test.com'
-      config.statsd_port         = '1234'
-      config.pod_name            = 'sample_pod'
-      config.statsd_socket_path  = '/var/lib/statsd/statsd.sock'
-      config.statsd_grouping     = 'sample_group'
-      config.metric_prefix       = 'sample'
-      config.dd_tags             = 'aaa,bbb'
-      config.dd_env              = 'staging'
-      config.dd_service          = 'sample_service'
-      config.dd_version          = '2.0.0'
-      config.dd_entity_id        = 'sample_entity_id'
+      config.statsd_host           = 'test.com'
+      config.statsd_port           = '1234'
+      config.pod_name              = 'sample_pod'
+      config.statsd_socket_path    = '/var/lib/statsd/statsd.sock'
+      config.statsd_grouping       = 'sample_group'
+      config.statsd_sleep_interval = '0.5'
+      config.metric_prefix         = 'sample'
+      config.dd_tags               = 'aaa,bbb'
+      config.dd_env                = 'staging'
+      config.dd_service            = 'sample_service'
+      config.dd_version            = '2.0.0'
+      config.dd_entity_id          = 'sample_entity_id'
     end
 
     assert_equal 'test.com'                   , PumaStatsd.config.statsd_host
@@ -80,6 +84,7 @@ class ConfigTest < MiniTest::Test
     assert_equal 'sample_pod'                 , PumaStatsd.config.pod_name
     assert_equal '/var/lib/statsd/statsd.sock', PumaStatsd.config.statsd_socket_path
     assert_equal 'sample_group'               , PumaStatsd.config.statsd_grouping
+    assert_equal '0.5'                        , PumaStatsd.config.statsd_sleep_interval
     assert_equal 'sample'                     , PumaStatsd.config.metric_prefix
     assert_equal 'aaa,bbb'                    , PumaStatsd.config.dd_tags
     assert_equal 'staging'                    , PumaStatsd.config.dd_env

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,109 @@
+require 'test_helper'
+
+class ConfigTest < MiniTest::Test
+  def setup
+    # Do nothing
+  end
+
+  def teardown
+    PumaStatsd.reset_config
+    %w[
+        STATSD_HOST
+        STATSD_PORT
+        STATSD_SOCKET_PATH
+        MY_POD_NAME
+        STATSD_GROUPING
+        STATSD_METRIC_PREFIX
+        DD_TAGS
+        DD_ENV
+        DD_SERVICE
+        DD_VERSION
+        DD_ENTITY_ID
+    ].each {|var| ENV.delete var }
+  end
+
+  def test_config
+    assert_kind_of OpenStruct, PumaStatsd.config
+  end
+
+  def test_config_defaults
+    assert_nil PumaStatsd.config.pod_name
+    assert_nil PumaStatsd.config.statsd_grouping
+
+    assert_equal '127.0.0.1', PumaStatsd.config.statsd_host
+    assert_equal 8125       , PumaStatsd.config.statsd_port
+  end
+
+  def test_config_from_default_env
+    ENV['STATSD_HOST']          = 'test.com'
+    ENV['STATSD_PORT']          = '1234'
+    ENV['MY_POD_NAME']          = 'sample_pod'
+    ENV['STATSD_SOCKET_PATH']   = '/var/lib/statsd/statsd.sock'
+    ENV['STATSD_GROUPING']      = 'sample_group'
+    ENV['STATSD_METRIC_PREFIX'] = 'sample'
+    ENV['DD_TAGS']              = 'aaa,bbb'
+    ENV['DD_ENV']               = 'staging'
+    ENV['DD_SERVICE']           = 'sample_service'
+    ENV['DD_VERSION']           = '2.0.0'
+    ENV['DD_ENTITY_ID']         = 'sample_entity_id'
+
+    assert_equal 'test.com'                   , PumaStatsd.config.statsd_host
+    assert_equal '1234'                       , PumaStatsd.config.statsd_port
+    assert_equal 'sample_pod'                 , PumaStatsd.config.pod_name
+    assert_equal '/var/lib/statsd/statsd.sock', PumaStatsd.config.statsd_socket_path
+    assert_equal 'sample_group'               , PumaStatsd.config.statsd_grouping
+    assert_equal 'sample'                     , PumaStatsd.config.metric_prefix
+    assert_equal 'aaa,bbb'                    , PumaStatsd.config.dd_tags
+    assert_equal 'staging'                    , PumaStatsd.config.dd_env
+    assert_equal 'sample_service'             , PumaStatsd.config.dd_service
+    assert_equal '2.0.0'                      , PumaStatsd.config.dd_version
+    assert_equal 'sample_entity_id'           , PumaStatsd.config.dd_entity_id
+  end
+
+  def test_configure_block
+    PumaStatsd.configure do |config|
+      config.statsd_host         = 'test.com'
+      config.statsd_port         = '1234'
+      config.pod_name            = 'sample_pod'
+      config.statsd_socket_path  = '/var/lib/statsd/statsd.sock'
+      config.statsd_grouping     = 'sample_group'
+      config.metric_prefix       = 'sample'
+      config.dd_tags             = 'aaa,bbb'
+      config.dd_env              = 'staging'
+      config.dd_service          = 'sample_service'
+      config.dd_version          = '2.0.0'
+      config.dd_entity_id        = 'sample_entity_id'
+    end
+
+    assert_equal 'test.com'                   , PumaStatsd.config.statsd_host
+    assert_equal '1234'                       , PumaStatsd.config.statsd_port
+    assert_equal 'sample_pod'                 , PumaStatsd.config.pod_name
+    assert_equal '/var/lib/statsd/statsd.sock', PumaStatsd.config.statsd_socket_path
+    assert_equal 'sample_group'               , PumaStatsd.config.statsd_grouping
+    assert_equal 'sample'                     , PumaStatsd.config.metric_prefix
+    assert_equal 'aaa,bbb'                    , PumaStatsd.config.dd_tags
+    assert_equal 'staging'                    , PumaStatsd.config.dd_env
+    assert_equal 'sample_service'             , PumaStatsd.config.dd_service
+    assert_equal '2.0.0'                      , PumaStatsd.config.dd_version
+    assert_equal 'sample_entity_id'           , PumaStatsd.config.dd_entity_id
+  end
+
+  def test_configure_block_takes_precedence
+    ENV['STATSD_HOST']      = 'bad.com'
+    ENV['STATSD_PORT']      = '9876'
+    ENV['MY_POD_NAME']      = 'bad_pod'
+    ENV['STATSD_GROUPING']  = 'bad_group'
+
+    PumaStatsd.configure do |config|
+      config.statsd_host = 'test.com'
+      config.statsd_port = '1234'
+      config.pod_name = 'sample_pod'
+      config.statsd_grouping = 'sample_group'
+    end
+
+    assert_equal 'test.com'     , PumaStatsd.config.statsd_host
+    assert_equal '1234'         , PumaStatsd.config.statsd_port
+    assert_equal 'sample_pod'   , PumaStatsd.config.pod_name
+    assert_equal 'sample_group' , PumaStatsd.config.statsd_grouping
+  end
+end

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -4,4 +4,47 @@ class PluginTest < Minitest::Test
   def test_registration
     assert_kind_of Class, Puma::Plugins.find("statsd")
   end
+
+    def test_tags_empty_default
+    assert_nil plugin.send(:environment_variable_tags)
+  end
+
+  def test_tags_from_env
+    ENV['MY_POD_NAME'] = 'sample_pod'
+    ENV['STATSD_GROUPING'] = 'sample_grouping'
+    tags = plugin.send(:environment_variable_tags).split(',')
+
+    assert_includes tags, 'pod_name:sample_pod'
+    assert_includes tags, 'grouping:sample_grouping'
+  end
+
+  def test_tags_from_config
+    PumaStatsd.config.pod_name = 'pod_name_from_config'
+    PumaStatsd.config.statsd_grouping = 'grouping_from_config'
+    tags = plugin.send(:environment_variable_tags).split(',')
+
+    assert_includes tags, 'pod_name:pod_name_from_config'
+    assert_includes tags, 'grouping:grouping_from_config'
+  end
+
+  def teardown
+    PumaStatsd.reset_config
+    %w[
+        STATSD_HOST
+        STATSD_PORT
+        STATSD_SOCKET_PATH
+        MY_POD_NAME
+        STATSD_GROUPING
+        STATSD_METRIC_PREFIX
+        DD_TAGS
+        DD_ENV
+        DD_SERVICE
+        DD_VERSION
+        DD_ENTITY_ID
+    ].each {|var| ENV.delete var }
+  end
+
+  def plugin
+    Puma::PluginLoader.new.create("statsd")
+  end
 end

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -36,6 +36,7 @@ class PluginTest < Minitest::Test
         MY_POD_NAME
         STATSD_GROUPING
         STATSD_METRIC_PREFIX
+        STATSD_SLEEP_INTERVAL
         DD_TAGS
         DD_ENV
         DD_SERVICE

--- a/test/puma_stats_test.rb
+++ b/test/puma_stats_test.rb
@@ -61,4 +61,15 @@ class PumaStatsTest < MiniTest::Test
     assert_equal 6, cluster_stats.max_threads
     assert_equal 3, worker_stats.max_threads
   end
+
+  def test_percent_busy
+    assert_equal 33, cluster_stats.percent_busy
+    assert_equal 33, worker_stats.percent_busy
+  end
+
+  def test_percent_busy_zero_max_threads
+    ws = worker_statistics
+    ws[:max_threads] = 0
+    assert_equal 0, PumaStats.new(ws).percent_busy
+  end
 end

--- a/test/puma_stats_test.rb
+++ b/test/puma_stats_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class PumaStatsTest < MiniTest::Test
+  extend Minitest::Spec::DSL
+
+  let(:cluster_statistics) do
+    {
+        workers: 2,
+        booted_workers: 2,
+        worker_status: [worker_statistics,worker_statistics].map {|w| {last_status: w}}
+    }
+  end
+
+  let(:worker_statistics) do
+    {
+        running: 1,
+        backlog: 5,
+        pool_capacity: 2,
+        max_threads: 3
+    }
+  end
+
+  let(:cluster_stats) { PumaStats.new(cluster_statistics) }
+  let(:worker_stats) { PumaStats.new(worker_statistics) }
+
+  def setup
+    # Do nothing
+  end
+
+  def test_clustered?
+    assert cluster_stats.clustered?
+    refute worker_stats.clustered?
+  end
+
+  def test_workers
+    assert_equal 2,cluster_stats.workers
+    assert_equal 1,worker_stats.workers
+  end
+
+  def test_booted_workers
+    assert_equal 2,cluster_stats.booted_workers
+    assert_equal 1,worker_stats.booted_workers
+  end
+
+  def test_running
+    assert_equal 2, cluster_stats.running
+    assert_equal 1, worker_stats.running
+  end
+
+  def test_backlog
+    assert_equal 10, cluster_stats.backlog
+    assert_equal 5, worker_stats.backlog
+  end
+
+  def test_pool_capacity
+    assert_equal 4, cluster_stats.pool_capacity
+    assert_equal 2, worker_stats.pool_capacity
+  end
+
+  def test_max_threads
+    assert_equal 6, cluster_stats.max_threads
+    assert_equal 3, worker_stats.max_threads
+  end
+end

--- a/test/statsd_connector_test.rb
+++ b/test/statsd_connector_test.rb
@@ -67,6 +67,22 @@ class StatsdConnectorTest < Minitest::Test
     assert mock_socket.verify
   end
 
+  def test_sends_histogram_metric
+    ENV["STATSD_HOST"] = 'test.com'
+    ENV["STATSD_PORT"] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ["test:1|h", Integer,String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :histogram)
+    end
+
+    assert mock_socket.verify
+  end
+  
   def teardown
     %w[STATSD_HOST STATSD_PORT].each {|var| ENV.delete var }
     PumaStatsd.reset_config

--- a/test/statsd_connector_test.rb
+++ b/test/statsd_connector_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class StatsdConnectorTest < Minitest::Test
+  def test_host
+    ENV['STATSD_HOST'] = 'test.com'
+
+    connector = StatsdConnector.new
+    assert_equal 'test.com', connector.host
+  end
+
+  def test_port
+    ENV['STATSD_PORT'] = '1234'
+    connector = StatsdConnector.new
+    assert_equal "1234", connector.port
+  end
+
+  def test_port_default
+    connector = StatsdConnector.new
+    assert_equal 8125, connector.port
+  end
+
+  def test_sends_to_configured_host_port
+    ENV['STATSD_HOST'] = 'test.com'
+    ENV['STATSD_PORT'] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, [String, Integer, 'test.com', '1234']
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :count)
+    end
+
+    assert mock_socket.verify
+  end
+
+  def test_sends_count_metric
+    ENV['STATSD_HOST'] = 'test.com'
+    ENV['STATSD_PORT'] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ['test:1|c', Integer, String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :count)
+    end
+
+    assert mock_socket.verify
+  end
+
+  def test_sends_gauge_metric
+    ENV['STATSD_HOST'] = 'test.com'
+    ENV['STATSD_PORT'] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ['test:1|g', Integer,String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :gauge)
+    end
+
+    assert mock_socket.verify
+  end
+
+  def teardown
+    %w[STATSD_HOST STATSD_PORT].each {|var| ENV.delete var }
+    PumaStatsd.reset_config
+  end
+end


### PR DESCRIPTION
Add a new metrics, showing how much of pool capacity is taken with existing threads. Collected as a histogram by default, but configurable.

Relies on #48 and #50. Right after #48, #49 and #50 is merged, I will update this to only contain it's own changes. Start from #48 if you arrived here first.