### PR TITLE
Allow sleep interval to be configured with STATSD_INTERVAL_SECONDS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ If statsd isn't on 127.0.0.1 or the port is non-standard, you can configure them
 STATSD_HOST=127.0.0.1 STATSD_PORT=9125 bundle exec puma
 ```
 
+### Configuration
+
+By default values will be reported to statsd every 2 seconds. To customise that
+internal, set the `STATSD_INTERVAL_SECONDS` environment variable.
+
+STATSD_INTERVAL_SECONDS=1 bundle exec puma
+
+Fractional seconds are supported. Here's how you'd opt into 500ms:
+
+STATSD_INTERVAL_SECONDS="0.5" bundle exec puma
+
 ### Datadog Integration
 
 metric tags are a non-standard addition to the statsd protocol, supported by

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -109,7 +109,7 @@ Puma::Plugin.create do
       end
 
     @statsd = ::StatsdConnector.new
-    @interval = ENV.fetch("STATSD_SLEEP_INTERNAL", "2").to_f
+    @interval_seconds = ENV.fetch("STATSD_INTERVAL_SECONDS", "2").to_f
     @log_writer.debug "statsd: enabled (host: #{@statsd.host}, interval: #{@interval})"
 
     # Fetch global metric prefix from env variable
@@ -210,7 +210,7 @@ Puma::Plugin.create do
       rescue StandardError => e
         @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
-        sleep @interval
+        sleep @interval_seconds
       end
     end
   end

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -109,7 +109,8 @@ Puma::Plugin.create do
       end
 
     @statsd = ::StatsdConnector.new
-    @log_writer.debug "statsd: enabled (host: #{@statsd.host})"
+    @interval = ENV.fetch("STATSD_SLEEP_INTERNAL", "2").to_f
+    @log_writer.debug "statsd: enabled (host: #{@statsd.host}, interval: #{@interval})"
 
     # Fetch global metric prefix from env variable
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
@@ -209,7 +210,7 @@ Puma::Plugin.create do
       rescue StandardError => e
         @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
-        sleep 2
+        sleep @interval
       end
     end
   end


### PR DESCRIPTION
Replaces #40. I've rebased onto main to resolve a conflict, and opted for a slightly different ENV name.

The different users have shared on #40 that allowing this to be customised from the default of 2s is useful - presumably most folks are interested in reducing it.

Thanks @Mongey!