### PR TITLE
Add new puma.requests metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [Puma][puma] integration with [statsd][statsd] for easy tracking of key metrics
 that puma can provide:
 
+Gauges:
+
 * puma.workers
 * puma.booted_workers
 * puma.running
@@ -10,7 +12,11 @@ that puma can provide:
 * puma.pool_capacity
 * puma.max_threads
 * puma.old_workers
-* puma.requests_count
+* puma.requests_count - Total number of requests served by this puma since it started
+
+Counters:
+
+* puma.requests - The number of requests served since the previous report
 
   [puma]: https://github.com/puma/puma
   [statsd]: https://github.com/etsy/statsd

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -36,8 +36,9 @@ end
 
 # Wrap puma's stats in a safe API
 class PumaStats
-  def initialize(stats)
+  def initialize(stats, previous_requests_count = 0)
     @stats = stats
+    @previous_requests_count = previous_requests_count
   end
 
   def clustered?
@@ -90,10 +91,12 @@ class PumaStats
 
   def requests_count
     if clustered?
-      @stats[:worker_status].map { |s| s[:last_status].fetch(:requests_count, 0) }.inject(0, &:+)
+      count = @stats[:worker_status].map { |s| s[:last_status].fetch(:requests_count, 0) }.inject(0, &:+)
     else
-      @stats.fetch(:requests_count, 0)
+      count = @stats.fetch(:requests_count, 0)
     end
+
+    return count - @previous_requests_count
   end
 end
 
@@ -193,12 +196,14 @@ Puma::Plugin.create do
   # Send data to statsd every few seconds
   def stats_loop
     tags = environment_variable_tags
+    previous_requests_count = 0
 
     sleep 5
     loop do
       @log_writer.debug "statsd: notify statsd"
       begin
-        stats = ::PumaStats.new(Puma.stats_hash)
+        stats = ::PumaStats.new(Puma.stats_hash, previous_requests_count)
+        previous_requests_count += stats.requests_count
         @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.booted_workers"), value: stats.booted_workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.old_workers"), value: stats.old_workers, type: :gauge, tags: tags)
@@ -206,7 +211,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.backlog"), value: stats.backlog, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.pool_capacity"), value: stats.pool_capacity, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
-        @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :count, tags: tags)
       rescue StandardError => e
         @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure


### PR DESCRIPTION
Confusingly, the puma metric called "requests_count" is actually a gauge in statsd terms. It's the sum of all requests that have been served since this puma was booted, always increasing.

Confusing name aside, a gauge of total requests served is useful. However, it can always be useful to report the delta as a statsd counter. That is, the number of requests served since the last time we reported (by default, 2 seconds ago).

It was tempting to change puma.requests_count to be the statsd counter and move the gauge to a new name. That would be a breaking change though, and I wasn't willing to do that.

Originally from #39. I've rebased onto current main and tweaking the name. Thanks @kimvsparrow ❤️