### PR TITLE
Add percent_busy metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Gauges:
 * puma.backlog - The number of requests that have made it to a worker but are yet to be processed. This will normally be zero, as requests queue on the tcp/unix socket in front of the master puma process, not in the worker thread pool
 * puma.pool_capacity - The number of idle and unused worker threads. When this is low/zero, puma is running at full capacity and might need scaling up
 * puma.max_threads - The maximum number of worker threads that might run at one time
+* puma.percent_busy - The percentage of busy threads calculated as pool capacity relative to max threads
 * puma.requests_count - Total number of requests served by this puma since it started
 
 Counters:

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -97,6 +97,10 @@ class PumaStats
     end
   end
 
+  def percent_busy
+    (1 - (pool_capacity / max_threads.to_f)) * 100
+  end
+
   def requests_delta
     requests_count - @previous_requests_count
   end
@@ -213,6 +217,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.backlog"), value: stats.backlog, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.pool_capacity"), value: stats.pool_capacity, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.percent_busy"), value: stats.percent_busy, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests"), value: stats.requests_delta, type: :count, tags: tags)
       rescue StandardError => e


### PR DESCRIPTION
The same idea as #51 just implemented within the existing code structure.

This metric is helpful to determine how loaded the puma instances are.

It's a simple calculation derived from existing metrics so it could be easily
calculated in the consumer of the metrics. Unfortunately when using Datadog and
Kubernetes horizontal pod autoscaling it's not possible to derive or calculate
a metric, the metric must be materialized as a regular metric in Datadog.
