### PR TITLE
Add puma.io_threads metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Gauges:
 * puma.backlog - The number of requests that have made it to a worker but are yet to be processed. This will be zero if queue_requests is disabled, as requests will only queue on the tcp/unix socket in front of the master puma process, but not in the worker thread pool
 * puma.pool_capacity - The number of idle and unspawned worker threads. When this is low/zero, puma is running at full capacity and might need scaling up
 * puma.max_threads - The maximum number of worker threads that might run at one time
+* puma.io_threads - The number of worker threads currently marked as IO-bound.
 * puma.percent_busy - The percentage of busy threads, calculated as the percentage of capacity in use relative to the maximum number of threads
 * puma.requests_count - Total number of requests served by this puma since it started
 

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -89,6 +89,14 @@ class PumaStats
     end
   end
 
+  def io_threads
+    if clustered?
+      @stats[:worker_status].map { |s| s[:last_status].fetch(:io_threads, 0) }.inject(0, &:+)
+    else
+      @stats.fetch(:io_threads, 0)
+    end
+  end
+
   def requests_count
     if clustered?
       @stats[:worker_status].map { |s| s[:last_status].fetch(:requests_count, 0) }.inject(0, &:+)
@@ -217,6 +225,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.backlog"), value: stats.backlog, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.pool_capacity"), value: stats.pool_capacity, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
+        @statsd.send(metric_name: prefixed_metric_name("puma.io_threads"), value: stats.io_threads, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.percent_busy"), value: stats.percent_busy, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests"), value: stats.requests_delta, type: :count, tags: tags)


### PR DESCRIPTION
Adds a `puma.io_threads` gauge: the count of worker threads puma currently has marked as IO-bound (allowed to run beyond `max_threads` when `max_io_threads` is set), surfacing the `io_threads` stat added in [puma#76f98d3](https://github.com/puma/puma/commit/76f98d31c989c962af7c062625c6879b132bb33d).

Follows the same pattern as #58 (Add percent_busy metric). `PumaStats#io_threads` mirrors the existing thread accessors (sums `worker_status` when clustered, top-level key otherwise) and uses `fetch(:io_threads, 0)`, so it reports 0 on older puma versions rather than raising.